### PR TITLE
Minor bmon fixes

### DIFF
--- a/bmon/infra.py
+++ b/bmon/infra.py
@@ -586,7 +586,7 @@ def setup_bitcoind_exporter(
 
     if not docker.image_exists(image_name):
         with fscm.cd(gitpath):
-            run(f"docker build --tag {image_name} .")
+            run(f"docker build --tag {image_name} .", sudo=True)
 
     uid = "$(id -u)"
     if running_podman():

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,9 @@ setup(
     zip_safe=False,
     packages=['bmon'],
     install_requires=[
-        'mitogen @ git+ssh://git@github.com/jamesob/mitogen.git'
-        'fscm @ git+ssh://git@github.com/jamesob/fscm.git'
+        'mitogen @ git+ssh://git@github.com/jamesob/mitogen.git',
+        'fscm @ git+ssh://git@github.com/jamesob/fscm.git',
+        'clii'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
bmon's setup.py has a typo (missing comma in dependency list) and is missing clii as dependency.

fscm internals cause and error when trying to build docker images as user because group memberships are not updated after adding an user to a group.